### PR TITLE
Fix transaction type for selling

### DIFF
--- a/src/components/SellCryptoModal.tsx
+++ b/src/components/SellCryptoModal.tsx
@@ -97,7 +97,7 @@ const SellCryptoModal: React.FC<SellCryptoModalProps> = ({ isOpen, onClose, hold
         .insert({
           user_id: user.id,
           cryptocurrency_id: holding.crypto.id,
-          transaction_type: 'trade_sell',
+          transaction_type: 'sell',
           amount: sellAmountValue,
           usd_value: eurValue,
           fee_amount: feeAmount,


### PR DESCRIPTION
## Summary
- use `sell` transaction type when recording sell transactions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ffc3ec0a483208ca19b942195e9c6