### PR TITLE
Implement CryptoPnLCalculator

### DIFF
--- a/src/components/SellCryptoModal.tsx
+++ b/src/components/SellCryptoModal.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -11,6 +11,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { formatCryptoQuantity } from '@/lib/cryptoFormatters';
+import CryptoPnLCalculator from '@/lib/CryptoPnLCalculator';
 
 interface SellCryptoModalProps {
   isOpen: boolean;
@@ -32,6 +33,7 @@ interface SellCryptoModalProps {
 const SellCryptoModal: React.FC<SellCryptoModalProps> = ({ isOpen, onClose, holding }) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const pnlCalcRef = useRef(new CryptoPnLCalculator());
   const [sellAmount, setSellAmount] = useState('');
   const [sellType, setSellType] = useState<'partial' | 'full'>('partial');
   const [isLoading, setIsLoading] = useState(false);
@@ -63,6 +65,14 @@ const SellCryptoModal: React.FC<SellCryptoModalProps> = ({ isOpen, onClose, hold
     try {
       const eurValue = sellAmountValue * holding.crypto.current_price;
       const feeAmount = eurValue * 0.0035; // 0.35% fee
+
+      // update PnL calculator before executing
+      try {
+        const result = pnlCalcRef.current.addSell(holding.crypto.symbol, sellAmountValue, eurValue);
+        console.log('[SellModal] PnL result', result);
+      } catch (err) {
+        console.error('[SellModal] PnL calculation error', err);
+      }
       
       console.log('[SellModal] Starting sell transaction:', {
         userId: user.id,

--- a/src/hooks/useTrade.ts
+++ b/src/hooks/useTrade.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { useAuth } from './useAuth';
@@ -6,11 +6,13 @@ import { Cryptocurrency } from './useCryptocurrencies';
 import { useQueryClient } from '@tanstack/react-query';
 import { useExchangeRate } from './useExchangeRate';
 import { convertUsdToEur, convertEurToUsd } from '@/lib/currencyConverter';
+import CryptoPnLCalculator from '@/lib/CryptoPnLCalculator';
 
 export const useTrade = (crypto: Cryptocurrency | undefined) => {
   const { user } = useAuth();
   const { exchangeRate } = useExchangeRate();
   const queryClient = useQueryClient();
+  const pnlCalculatorRef = useRef(new CryptoPnLCalculator());
   
   const [tradeType, setTradeType] = useState<'buy' | 'sell'>('buy');
   const [paymentMethod, setPaymentMethod] = useState<'balance' | 'ideal'>('balance');
@@ -145,6 +147,18 @@ export const useTrade = (crypto: Cryptocurrency | undefined) => {
 
     setIsProcessingTrade(true);
     const logPrefix = `[Trade-Step]`;
+
+    // Update PnL calculator before processing trade
+    try {
+      if (tradeType === 'buy') {
+        pnlCalculatorRef.current.addBuy(crypto.symbol, coinAmount, eurValue);
+      } else {
+        const result = pnlCalculatorRef.current.addSell(crypto.symbol, coinAmount, eurValue);
+        console.log('[useTrade] PnL result', result);
+      }
+    } catch (err) {
+      console.error('[useTrade] PnL calculation error', err);
+    }
 
     try {
       // Step 1: Create trading order (store in USD)

--- a/src/lib/CryptoPnLCalculator.ts
+++ b/src/lib/CryptoPnLCalculator.ts
@@ -1,0 +1,239 @@
+export interface HoldingLot {
+  quantity: number;
+  price: number;
+  timestamp: number;
+}
+
+export interface SoldLot extends HoldingLot {
+  soldQuantity: number;
+}
+
+export interface SellPnlDetail {
+  quantity: number;
+  costBasis: number;
+  saleValue: number;
+  pnl: number;
+  originalPurchaseTimestamp: number;
+}
+
+export interface SellPnlResult {
+  totalQuantitySold: number;
+  totalCostBasis: number;
+  totalSaleValue: number;
+  totalPnL: number;
+  details: SellPnlDetail[];
+}
+
+export interface MarketValue {
+  totalValue: number;
+  quantity: number;
+}
+
+export interface UnrealizedPnLData {
+  quantity: number;
+  avgCostBasis: number;
+  totalCostBasis: number;
+  currentValue: number;
+  unrealizedPnL: number;
+  unrealizedPnLPercent: number;
+}
+
+export interface PortfolioTotals {
+  realizedPnL: number;
+  unrealizedPnL: number;
+  totalPnL: number;
+  totalCurrentValue: number;
+  totalCostBasis: number;
+  totalReturnPercent: number;
+}
+
+export class CryptoPnLCalculator {
+  private method: 'FIFO' | 'LIFO' | 'SPECIFIC';
+  private holdings: Map<string, HoldingLot[]>;
+  private realizedPnL: number;
+
+  constructor(method: 'FIFO' | 'LIFO' | 'SPECIFIC' = 'FIFO') {
+    this.method = method;
+    this.holdings = new Map();
+    this.realizedPnL = 0;
+  }
+
+  addBuy(symbol: string, quantity: number, totalCostIncludingFees: number, timestamp: number = Date.now()): void {
+    const avgPrice = totalCostIncludingFees / quantity;
+
+    if (!this.holdings.has(symbol)) {
+      this.holdings.set(symbol, []);
+    }
+
+    this.holdings.get(symbol)!.push({ quantity, price: avgPrice, timestamp });
+  }
+
+  addSell(symbol: string, quantity: number, totalSaleValueAfterFees: number, timestamp: number = Date.now()): SellPnlResult {
+    const holdings = this.holdings.get(symbol);
+    if (!holdings || this.getTotalQuantity(symbol) < quantity) {
+      throw new Error(`Insufficient ${symbol} holdings for sale`);
+    }
+
+    const soldHoldings = this.selectHoldingsToSell(symbol, quantity);
+    const pnlResult = this.calculateSellPnL(soldHoldings, totalSaleValueAfterFees);
+    this.realizedPnL += pnlResult.totalPnL;
+    return pnlResult;
+  }
+
+  addTrade(fromSymbol: string, fromQuantity: number, toSymbol: string, toQuantity: number, totalFromValue: number, totalToValue: number, timestamp: number = Date.now()): SellPnlResult {
+    const sellPnL = this.addSell(fromSymbol, fromQuantity, totalFromValue, timestamp);
+    this.addBuy(toSymbol, toQuantity, totalToValue, timestamp);
+    return sellPnL;
+  }
+
+  selectHoldingsToSell(symbol: string, quantityToSell: number): SoldLot[] {
+    const holdings = this.holdings.get(symbol)!;
+    const soldHoldings: SoldLot[] = [];
+    let remaining = quantityToSell;
+
+    const sorted = [...holdings].sort((a, b) => {
+      if (this.method === 'FIFO') return a.timestamp - b.timestamp;
+      if (this.method === 'LIFO') return b.timestamp - a.timestamp;
+      return 0;
+    });
+
+    for (let i = 0; i < sorted.length && remaining > 0; i++) {
+      const holding = sorted[i];
+      const qty = Math.min(holding.quantity, remaining);
+      soldHoldings.push({ ...holding, soldQuantity: qty });
+      holding.quantity -= qty;
+      remaining -= qty;
+      if (holding.quantity === 0) {
+        const index = holdings.indexOf(holding);
+        holdings.splice(index, 1);
+      }
+    }
+    return soldHoldings;
+  }
+
+  calculateSellPnL(soldHoldings: SoldLot[], totalSaleValue: number): SellPnlResult {
+    let totalCostBasis = 0;
+    let totalQuantitySold = 0;
+    const details: SellPnlDetail[] = [];
+    const totalQuantity = soldHoldings.reduce((sum, h) => sum + h.soldQuantity, 0);
+
+    soldHoldings.forEach(holding => {
+      const costBasis = holding.price * holding.soldQuantity;
+      const proportionalSaleValue = (holding.soldQuantity / totalQuantity) * totalSaleValue;
+      const pnl = proportionalSaleValue - costBasis;
+      details.push({
+        quantity: holding.soldQuantity,
+        costBasis,
+        saleValue: proportionalSaleValue,
+        pnl,
+        originalPurchaseTimestamp: holding.timestamp,
+      });
+      totalCostBasis += costBasis;
+      totalQuantitySold += holding.soldQuantity;
+    });
+
+    const totalPnL = totalSaleValue - totalCostBasis;
+    return { totalQuantitySold, totalCostBasis, totalSaleValue, totalPnL, details };
+  }
+
+  calculateUnrealizedPnL(currentMarketValues: Record<string, MarketValue>): Map<string, UnrealizedPnLData> {
+    const unrealized = new Map<string, UnrealizedPnLData>();
+
+    this.holdings.forEach((lots, symbol) => {
+      if (!currentMarketValues[symbol]) return;
+      let totalCostBasis = 0;
+      let totalQuantity = 0;
+      lots.forEach(h => {
+        totalCostBasis += h.price * h.quantity;
+        totalQuantity += h.quantity;
+      });
+      const currentValue = currentMarketValues[symbol].totalValue;
+      const unrealizedPnL = currentValue - totalCostBasis;
+      unrealized.set(symbol, {
+        quantity: totalQuantity,
+        avgCostBasis: totalCostBasis / totalQuantity,
+        totalCostBasis,
+        currentValue,
+        unrealizedPnL,
+        unrealizedPnLPercent: totalCostBasis > 0 ? (unrealizedPnL / totalCostBasis) * 100 : 0,
+      });
+    });
+
+    return unrealized;
+  }
+
+  getTotalQuantity(symbol: string): number {
+    const lots = this.holdings.get(symbol);
+    if (!lots) return 0;
+    return lots.reduce((total, l) => total + l.quantity, 0);
+  }
+
+  getAvgCostBasis(symbol: string): number {
+    const lots = this.holdings.get(symbol);
+    if (!lots || lots.length === 0) return 0;
+    let totalCost = 0;
+    let totalQty = 0;
+    lots.forEach(l => {
+      totalCost += l.price * l.quantity;
+      totalQty += l.quantity;
+    });
+    return totalQty > 0 ? totalCost / totalQty : 0;
+  }
+
+  getPortfolioTotals(currentMarketValues: Record<string, MarketValue>): PortfolioTotals {
+    const unrealized = this.calculateUnrealizedPnL(currentMarketValues);
+    let totalUnrealizedPnL = 0;
+    let totalCurrentValue = 0;
+    let totalCostBasis = 0;
+    unrealized.forEach(d => {
+      totalUnrealizedPnL += d.unrealizedPnL;
+      totalCurrentValue += d.currentValue;
+      totalCostBasis += d.totalCostBasis;
+    });
+    return {
+      realizedPnL: this.realizedPnL,
+      unrealizedPnL: totalUnrealizedPnL,
+      totalPnL: this.realizedPnL + totalUnrealizedPnL,
+      totalCurrentValue,
+      totalCostBasis,
+      totalReturnPercent: totalCostBasis > 0 ? ((this.realizedPnL + totalUnrealizedPnL) / totalCostBasis) * 100 : 0,
+    };
+  }
+
+  getAllHoldings(): Map<string, { quantity: number; avgCostBasis: number; totalCostBasis: number; lots: HoldingLot[] }> {
+    const result = new Map<string, { quantity: number; avgCostBasis: number; totalCostBasis: number; lots: HoldingLot[] }>();
+    this.holdings.forEach((lots, symbol) => {
+      if (lots.length > 0) {
+        const totalQuantity = this.getTotalQuantity(symbol);
+        const avgCostBasis = this.getAvgCostBasis(symbol);
+        result.set(symbol, {
+          quantity: totalQuantity,
+          avgCostBasis,
+          totalCostBasis: avgCostBasis * totalQuantity,
+          lots: lots.map(l => ({ quantity: l.quantity, price: l.price, timestamp: l.timestamp })),
+        });
+      }
+    });
+    return result;
+  }
+
+  reset(): void {
+    this.holdings.clear();
+    this.realizedPnL = 0;
+  }
+
+  getRealizedPnL(): number {
+    return this.realizedPnL;
+  }
+
+  setMethod(method: 'FIFO' | 'LIFO' | 'SPECIFIC'): void {
+    if (['FIFO', 'LIFO', 'SPECIFIC'].includes(method)) {
+      this.method = method;
+    } else {
+      throw new Error('Invalid method. Use FIFO, LIFO, or SPECIFIC');
+    }
+  }
+}
+
+export default CryptoPnLCalculator;
+


### PR DESCRIPTION
## Summary
- add `CryptoPnLCalculator` module
- integrate calculator with `useTrade` hook and `SellCryptoModal`

## Testing
- `npm run lint` *(fails: 56 errors, 14 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ffe74cd588320b60ecd1a9a102a1b