### PR TITLE
Fix roulette jitter by stabilizing ghost keys

### DIFF
--- a/src/components/CryptoLogo.tsx
+++ b/src/components/CryptoLogo.tsx
@@ -70,10 +70,11 @@ const CryptoLogo: React.FC<CryptoLogoProps> = ({
   const imageUrl = (!imageError && logo_url) ? logo_url : fallbackUrl;
   
   return (
-    <img 
+    <img
       src={imageUrl}
       alt={`${name} logo`}
       className={`${sizeClasses[size]} ${className} rounded-full object-cover`}
+      loading="lazy"
       onError={() => {
         console.log(`[CryptoLogo] Image error for ${symbol} with URL: ${imageUrl}`);
         if (!imageError && logo_url && imageUrl === logo_url) {

--- a/src/components/SpinRoulette.tsx
+++ b/src/components/SpinRoulette.tsx
@@ -24,7 +24,9 @@ const CARD_WIDTH = 120;
 const CARD_MARGIN = 8;
 const TOTAL_CARD_WIDTH = CARD_WIDTH + CARD_MARGIN;
 const VISIBLE_CARDS = 7;
-const GHOST_CARDS = 20; // Increased for smoother experience
+// Number of placeholder cards placed before and after the winner
+// Lowered a bit to reduce initial network requests
+const GHOST_CARDS = 12;
 
 const getTierGlow = (tier: string) => {
   switch (tier) {
@@ -72,9 +74,10 @@ const buildCardsTrack = (
   for (let i = 0; i < GHOST_CARDS; i++) {
     // Mix items to avoid repetitive patterns
     const randomIndex = Math.floor(Math.random() * all.length);
-    surround.push({ 
-      ...all[randomIndex], 
-      id: `ghost-${i}-${Math.random()}`
+    surround.push({
+      ...all[randomIndex],
+      // Use stable id so the same element can be reused between spins
+      id: `ghost-${i}`
     });
   }
   


### PR DESCRIPTION
## Summary
- reuse ghost cards by using stable `ghost-${i}` ids and reduce `GHOST_CARDS`
- lazy load CryptoLogo images

## Testing
- `npm run lint` *(fails: 54 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685017b471cc83208d26221a3acc97d4